### PR TITLE
delegate for pangesture

### DIFF
--- a/CHKLineChart/CHKLineChart/Classes/CHKLineChart.swift
+++ b/CHKLineChart/CHKLineChart/Classes/CHKLineChart.swift
@@ -1591,6 +1591,16 @@ extension CHKLineChartView: UIGestureRecognizerDelegate {
     }
    
     
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        
+        if otherGestureRecognizer.view is UITableView{
+            
+            return true
+        }
+        
+        return false
+    }
+    
     
     /// 平移拖动操作
     ///


### PR DESCRIPTION
解决pangesture与tableview滑动手势的冲突，当chartview嵌套在tableviewcell的时候有用.